### PR TITLE
Correct minor errors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@ npm i react-validators
 React provides several useful proptype validators in order to ensure data being passed into
 components as props match their expected type.
 
-One common pattern is to have data-driven domain/model objects (for example, a "User") be passed 
-around to several different components that utilize this object in different ways. It's also 
-common for servers to not always return the full object shape for performance reasons. This can 
+One common pattern is to have data-driven domain/model objects (for example, a "User") be passed
+around to several different components that utilize this object in different ways. It's also
+common for servers to not always return the full object shape for performance reasons. This can
 lead to uncertainty about whether or not a given component has all of the data it needs.
- 
+
 Unfortunately, react's `PropTypes.shape` validator can fall a bit short here. Components can have
 varied requirements for a given shape's properties, and leads to rewriting the shape declaration
 in multiple places.  
 
-Furthermore, the data requirements of a given component should be defined in the file of that 
+Furthermore, the data requirements of a given component should be defined in the file of that
 component alone, and not redeclared in all of the components consuming that component.
 
 
@@ -37,7 +37,7 @@ export default Shape({
   id: Types.number,
   first_name: Types.string,
   last_name: Types.string,
-  profile_url: Types.string, 
+  profile_url: Types.string,
   pic: { // you can nest objects properties
     url: Types.string,
     width: Types.number,
@@ -53,13 +53,13 @@ import UserCard from './UserCard';
 import UserBadge from './UserBadge';
 
 export default class User extends React.Component {
-  static defaultProps = {
+  static propTypes = {
     user: UserShape.requires(`
         first_name,
         last_name,
       `) // the needs of *this* component
-      .passedTo(UserCard, 'user') // merges in the needs of UserCard
-      .passedTo(UserBadge, 'user') // merges in the needs of UserBadge
+      .passedInto(UserCard, 'user') // merges in the needs of UserCard
+      .passedInto(UserBadge, 'user') // merges in the needs of UserBadge
       .isRequired,
   }
   render() {
@@ -79,7 +79,7 @@ export default class User extends React.Component {
 import UserShape from './UserShape';
 
 export default class UserBadge extends React.Component {
-  static defaultProps = {
+  static propTypes = {
     user: UserShape.requires(`
       profile_url,
       pic: {
@@ -105,7 +105,7 @@ export default class UserBadge extends React.Component {
 import UserShape from './UserShape';
 
 export default class UserCard extends React.Component {
-  static defaultProps = {
+  static propTypes = {
     user: UserShape.requires(`
       id,
       first_name,


### PR DESCRIPTION
- The propTypes should be passed to `propTypes` instead of `defalutProps`.
- `passedTo` doesn't exist. The right function name is `passedInto`.
- Editor automatically removed some trailing spaces.

@lelandrichardson PTAL
