### PR TITLE
Fix propTypes crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "devDependencies": {
     "babel": "^5.8.23",
     "chai": "^3.4.0",
-    "mocha": "^2.3.3"
+    "mocha": "^2.3.3",
+    "react": "*"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/src/Shape.js
+++ b/src/Shape.js
@@ -79,7 +79,7 @@ function requires(defString) {
 }
 
 function passedInto(Component, propName) {
-  const propType = Component.propTypes[propName];
+  const propType = Component.propTypes ? Component.propTypes[propName] : {};
   const allRequires = mergeRequires(this[REQUIRE_DEF], propType[REQUIRE_DEF]);
   return enhance(this[SHAPE_DEF], allRequires);
 }

--- a/src/__tests__/Shape_spec.js
+++ b/src/__tests__/Shape_spec.js
@@ -107,6 +107,13 @@ describe('Shape', () => {
       expect(() => nestedShape.passedInto(Foo, 'foo')).to.throw;
     });
 
+    it('does not throw when a component lacks propTypes entirely', () => {
+      const validator = nestedShape.passedInto({}, 'foo');
+      valid(validator, {});
+      valid(validator, { foo: { boo: 1 } });
+      invalid(validator, { foo: 1 });
+    });
+
     describe('(Basic Shape)', () => {
       const FooBar = { propTypes: { foo: shape.requires(`foo, bar`) } };
       const BarBaz = { propTypes: { bar: shape.requires(`bar, baz`) } };


### PR DESCRIPTION
This ensures that when using `passedInto` on a component that may or may not have `.propTypes` defined, it doesn't crash.