### PR TITLE
allow proptypes@15.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.5.0"
   }
 }


### PR DESCRIPTION
This pr enables any proptype at 15 (it was release at 15.5, which is the earliest version).

We are experiencing an error during build time when bumping from react-validators 0.1.3 -> 0.1.5. This pr would allow us to test specific versions of the react prop-types package to pinpoint the source of the bug.

cc: @ljharb