### PR TITLE
fixes bug introduced by the prop-types@15.5.7 package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Advanced React PropType Validation",
   "main": "build/index.js",
   "scripts": {
-    "test": "mocha --compilers js:babel/register --recursive src/**/**/__tests__/*.js",
+    "mocha": "mocha --compilers js:babel/register --recursive src/**/**/__tests__/*.js",
+    "mocha:production": "NODE_ENV=production npm run mocha",
+    "test": "npm run mocha && npm run mocha:production",
     "build": "babel src --out-dir build",
     "prepublish": "npm run build"
   },

--- a/src/Shape.js
+++ b/src/Shape.js
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import { parse } from './parse';
 import nestedShape from './nestedShape';
 

--- a/src/__tests__/utils/validators.js
+++ b/src/__tests__/utils/validators.js
@@ -3,10 +3,13 @@ import { expect } from 'chai';
 import checkPropTypes from './checkPropTypes';
 
 export function valid(propTypes, value) {
-  expect(checkPropTypes({ value: propTypes }, { value }, 'value', 'Foo')).to.be.null;
+  expect(checkPropTypes({ value: propTypes }, { value }, 'value', 'Foo')).to.not.exist;
 }
 
 export function invalid(propTypes, value) {
+  if (process.env.NODE_ENV === 'production') {
+    return valid(propTypes, value);
+  }
   expect(checkPropTypes({ value: propTypes }, { value }, 'value', 'Foo')).to.be.instanceOf(Error);
 }
 

--- a/src/nestedShape.js
+++ b/src/nestedShape.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 export default function nestedShape(shape) {
@@ -11,5 +12,11 @@ export default function nestedShape(shape) {
       result[key] = shape[key];
     }
   }
-  return PropTypes.shape(result);
+  if (process.env.NODE_ENV === 'production') {
+    const shape = () => {};
+    shape.isRequired = () => {};
+    return shape;
+  } else {
+    return PropTypes.shape(result);
+  }
 }


### PR DESCRIPTION
this pr fixes a bug that was introduced by the prop-types@15.5.7 package where in production, prop-types would return a function that would result in being constantly overwritten because the returned object was being passed by reference, thus resulting in mutations.

cc @ljharb